### PR TITLE
Remove usb-uart jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,37 +25,11 @@ jobs:
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
 
-  get-usb-uart-release:
-    name: Get USB/UART Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch firmware files
-        uses: robinraju/release-downloader@v1
-        id: download-release
-        with:
-          repository: NabuCasa/zwave-esp-bridge
-          latest: true
-          fileName: "*"
-          out-file-path: zwave-esp-bridge
-
-      - name: Move files to version folder
-        run: |
-          version="${{ steps.download-release.outputs.tag_name }}"
-          mkdir -p "output/$version"
-          mv zwave-esp-bridge/* "output/$version/"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          path: output
-          name: zwave-esp-bridge
-
   upload-to-r2:
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     name: Upload to R2
     needs:
       - build-wifi-firmware
-      - get-usb-uart-release
     uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.8.1
     with:
       directory: ha-connect-zwa-2
@@ -67,7 +41,6 @@ jobs:
     uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.8.1
     needs:
       - build-wifi-firmware
-      - get-usb-uart-release
     with:
       version: ${{ github.event.release.tag_name }}
 


### PR DESCRIPTION
The shared workflows do not work with different version firmwares like we were attempting to do here. So until we have a better solution, removing this part.